### PR TITLE
fix(KP-325): periods has been removed from courseLink

### DIFF
--- a/public/js/app/pages/Curriculum.jsx
+++ b/public/js/app/pages/Curriculum.jsx
@@ -60,10 +60,9 @@ function CourseTableRows({ participations }) {
 
     const { courseCode, title, credits, creditUnitAbbr, comment } = course
     const currentTerm = getCurrentTerm()
-    const periods = creditsPerPeriod.length
     const courseNameCellData = (
       <>
-        <a href={courseLink(courseCode, language, { periods, term })}>{`${courseCode} ${title}`}</a>
+        <a href={courseLink(courseCode, language, { term })}>{`${courseCode} ${title}`}</a>
         {comment && <b className="course-comment">{comment}</b>}
       </>
     )

--- a/public/js/app/util/links.js
+++ b/public/js/app/util/links.js
@@ -15,9 +15,8 @@ function parentThirdCycleStudyLink(language) {
 }
 
 function courseLink(courseCode, language, { term = undefined } = {}) {
-  const startSign = term !== undefined && term !== '' ? '?' : ''
-  const startTerm = term !== undefined && term !== '' ? `startterm=${term}` : ''
-  return pageLink(`/student/kurser/kurs/${courseCode}${startSign}${startTerm}`, language) // outside link
+  const startTerm = term !== undefined && term !== '' ? `?startterm=${term}` : ''
+  return pageLink(`/student/kurser/kurs/${courseCode}${startTerm}`, language) // outside link
 }
 
 function courseSearchLink(courseCode, language) {

--- a/public/js/app/util/links.js
+++ b/public/js/app/util/links.js
@@ -14,12 +14,10 @@ function parentThirdCycleStudyLink(language) {
     : pageLink(`/utbildning/forskarutbildning/`, language)
 }
 
-function courseLink(courseCode, language, { periods = undefined, term = undefined } = {}) {
-  const startSign = (term !== undefined && term !== '') || periods !== undefined ? '?' : ''
-  const bindSign = term !== undefined && term !== '' && periods !== undefined ? '&' : ''
+function courseLink(courseCode, language, { term = undefined } = {}) {
+  const startSign = term !== undefined && term !== '' ? '?' : ''
   const startTerm = term !== undefined && term !== '' ? `startterm=${term}` : ''
-  const period = periods !== undefined ? `periods=${periods}` : ''
-  return pageLink(`/student/kurser/kurs/${courseCode}${startSign}${period}${bindSign}${startTerm}`, language) // outside link
+  return pageLink(`/student/kurser/kurs/${courseCode}${startSign}${startTerm}`, language) // outside link
 }
 
 function courseSearchLink(courseCode, language) {


### PR DESCRIPTION
We have removed periods from course link, and we could not find any other logic associated with retrieving this parameter to be removed.