### PR TITLE
chore: add parameters to docker-test template

### DIFF
--- a/.azure/azure-pipelines.pr.yml
+++ b/.azure/azure-pipelines.pr.yml
@@ -28,5 +28,7 @@ steps:
         - '$(Pipeline.Workspace)/github/docker-compose-unit-tests.yml'
         - '$(Pipeline.Workspace)/github/docker-compose-integration-tests.yml'
       dockerfilePath: $(dockerfilePath)
+      dockerComposePath: '/usr/libexec/docker/cli-plugins/docker-compose'
+      projectName: $(imageName)
       imageName: $(imageName)
       tag: $(tag)


### PR DESCRIPTION
`dockerComposePath`: Add parameters to use the docker-compose CLI plugin to combat https://github.com/microsoft/azure-pipelines-tasks/issues/17808.

`projectName`: New plugin does not allow capital letters int the projectName **KTH/kopps-public-react-web** so I have added a parameter to overwrite to **kopps-public-react-web**
