### PR TITLE
fix(KP-324): use replaceAppWithWWW argument as false while creating PDF links in pdfAPI

### DIFF
--- a/public/js/app/pages/ProgramSyllabusExport.jsx
+++ b/public/js/app/pages/ProgramSyllabusExport.jsx
@@ -131,13 +131,13 @@ function ProgramSyllabusExport({ applicationStore }) {
       'appendix2'
     )
 
-    const pdfResponse = generateProgramSyllabus(getCurrentHost(thisHostBaseUrl, false), {
+    const pdfResponse = generateProgramSyllabus(getCurrentHost(thisHostBaseUrl), {
       pages: [
         completeHTMLForPdfObjExtElgbImlpContainer,
         completeHTMLForPdfAppendix1Container,
         completeHTMLForPdfAppendix2Container,
       ],
-      baseUrl: getCurrentHost(thisHostBaseUrl, false),
+      baseUrl: getCurrentHost(thisHostBaseUrl),
       course: programmeCode + '-' + term + '.pdf',
     })
     pdfResponse.then(

--- a/public/js/app/pages/ProgramSyllabusExport.jsx
+++ b/public/js/app/pages/ProgramSyllabusExport.jsx
@@ -131,13 +131,13 @@ function ProgramSyllabusExport({ applicationStore }) {
       'appendix2'
     )
 
-    const pdfResponse = generateProgramSyllabus(getCurrentHost(thisHostBaseUrl), {
+    const pdfResponse = generateProgramSyllabus(getCurrentHost(thisHostBaseUrl, false), {
       pages: [
         completeHTMLForPdfObjExtElgbImlpContainer,
         completeHTMLForPdfAppendix1Container,
         completeHTMLForPdfAppendix2Container,
       ],
-      baseUrl: getCurrentHost(thisHostBaseUrl),
+      baseUrl: getCurrentHost(thisHostBaseUrl, false),
       course: programmeCode + '-' + term + '.pdf',
     })
     pdfResponse.then(

--- a/public/js/app/util/__tests__/stringUtil.test.js
+++ b/public/js/app/util/__tests__/stringUtil.test.js
@@ -1,0 +1,137 @@
+import { getCurrentHost } from '../stringUtil'
+
+window = Object.create(window)
+const defaultOrigin = 'https://www.kth.se'
+Object.defineProperty(window, 'origin', {
+  value: defaultOrigin,
+  writable: true,
+})
+
+describe('getCurrentHost', () => {
+  beforeEach(() => {
+    window.origin = defaultOrigin
+  })
+
+  test('getCurrentHost takes "thisHostBaseUrl" and "keepAppOrigin"', () => {
+    getCurrentHost('someBaseUrl', false)
+  })
+
+  test.each(['someBaseUrl', 'someOtherBaseUrl'])(
+    'returns baseUrl unchanged if it does not contain "app" and no trailing slash: %s',
+    baseUrl => {
+      expect(getCurrentHost(baseUrl)).toStrictEqual(baseUrl)
+    }
+  )
+
+  describe('no trailing slash', () => {
+    describe('keepAppOrigin is undefined, i.e. default behaviour should be to replace www with app', () => {
+      test('if baseUrl contains "www", and origin contains "www", should return baseUrl unchanged', () => {
+        expect(getCurrentHost('www')).toStrictEqual('www')
+      })
+
+      test('if baseUrl contains "www-", but origin contains "app-", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app-r.referens.sys.kth.se'
+        expect(getCurrentHost('www-://foo')).toStrictEqual('app-://foo')
+        expect(getCurrentHost('www-://bar')).toStrictEqual('app-://bar')
+      })
+
+      test('if baseUrl contains "www.", but origin contains "app.", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app.kth.se'
+        expect(getCurrentHost('www.kth.se://foo')).toStrictEqual('app.kth.se://foo')
+        expect(getCurrentHost('www.kth.se://bar')).toStrictEqual('app.kth.se://bar')
+      })
+    })
+
+    describe('keepAppOrigin is true, www should be replaced with app', () => {
+      test('if baseUrl contains "www", and origin contains "www", should return baseUrl unchanged', () => {
+        expect(getCurrentHost('www', true)).toStrictEqual('www')
+      })
+
+      test('if baseUrl contains "www-", but origin contains "app-", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app-r.referens.sys.kth.se'
+        expect(getCurrentHost('www-://foo', true)).toStrictEqual('app-://foo')
+        expect(getCurrentHost('www-://bar', true)).toStrictEqual('app-://bar')
+      })
+
+      test('if baseUrl contains "www.", but origin contains "app.", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app.kth.se'
+        expect(getCurrentHost('www.kth.se://foo', true)).toStrictEqual('app.kth.se://foo')
+        expect(getCurrentHost('www.kth.se://bar', true)).toStrictEqual('app.kth.se://bar')
+      })
+    })
+
+    describe('keepAppOrigin is false, www should NOT be replaced with app', () => {
+      test('if baseUrl contains "www", and origin contains "www", should return baseUrl unchanged', () => {
+        expect(getCurrentHost('www', false)).toStrictEqual('www')
+      })
+
+      test('if baseUrl contains "www-", but origin contains "app-", should NOT return baseUrl with app instead for www', () => {
+        window.origin = 'https://app-r.referens.sys.kth.se'
+        expect(getCurrentHost('www-://foo', false)).toStrictEqual('www-://foo')
+        expect(getCurrentHost('www-://bar', false)).toStrictEqual('www-://bar')
+      })
+
+      test('if baseUrl contains "www.", but origin contains "app.", should NOT return baseUrl with app instead for www', () => {
+        window.origin = 'https://app.kth.se'
+        expect(getCurrentHost('www.kth.se://foo', false)).toStrictEqual('www.kth.se://foo')
+        expect(getCurrentHost('www.kth.se://bar', false)).toStrictEqual('www.kth.se://bar')
+      })
+    })
+  })
+
+  describe('trailing slash', () => {
+    describe('keepAppOrigin is undefined, i.e. default behaviour should be to replace www with app', () => {
+      test('if baseUrl contains "www", and origin contains "www", should return baseUrl unchanged', () => {
+        expect(getCurrentHost('www/')).toStrictEqual('www')
+      })
+
+      test('if baseUrl contains "www-", but origin contains "app-", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app-r.referens.sys.kth.se'
+        expect(getCurrentHost('www-://foo/')).toStrictEqual('app-://foo')
+        expect(getCurrentHost('www-://bar/')).toStrictEqual('app-://bar')
+      })
+
+      test('if baseUrl contains "www.", but origin contains "app.", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app.kth.se'
+        expect(getCurrentHost('www.kth.se://foo/')).toStrictEqual('app.kth.se://foo')
+        expect(getCurrentHost('www.kth.se://bar/')).toStrictEqual('app.kth.se://bar')
+      })
+    })
+
+    describe('keepAppOrigin is true, www should be replaced with app', () => {
+      test('if baseUrl contains "www", and origin contains "www", should return baseUrl unchanged', () => {
+        expect(getCurrentHost('www/', true)).toStrictEqual('www')
+      })
+
+      test('if baseUrl contains "www-", but origin contains "app-", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app-r.referens.sys.kth.se'
+        expect(getCurrentHost('www-://foo/', true)).toStrictEqual('app-://foo')
+        expect(getCurrentHost('www-://bar/', true)).toStrictEqual('app-://bar')
+      })
+
+      test('if baseUrl contains "www.", but origin contains "app.", should return baseUrl with app instead for www', () => {
+        window.origin = 'https://app.kth.se'
+        expect(getCurrentHost('www.kth.se://foo/', true)).toStrictEqual('app.kth.se://foo')
+        expect(getCurrentHost('www.kth.se://bar/', true)).toStrictEqual('app.kth.se://bar')
+      })
+    })
+
+    describe('keepAppOrigin is false, www should NOT be replaced with app', () => {
+      test('if baseUrl contains "www", and origin contains "www", should return baseUrl unchanged', () => {
+        expect(getCurrentHost('www/', false)).toStrictEqual('www')
+      })
+
+      test('if baseUrl contains "www-", but origin contains "app-", should NOT return baseUrl with app instead for www', () => {
+        window.origin = 'https://app-r.referens.sys.kth.se'
+        expect(getCurrentHost('www-://foo/', false)).toStrictEqual('www-://foo')
+        expect(getCurrentHost('www-://bar/', false)).toStrictEqual('www-://bar')
+      })
+
+      test('if baseUrl contains "www.", but origin contains "app.", should NOT return baseUrl with app instead for www', () => {
+        window.origin = 'https://app.kth.se'
+        expect(getCurrentHost('www.kth.se://foo/', false)).toStrictEqual('www.kth.se://foo')
+        expect(getCurrentHost('www.kth.se://bar/', false)).toStrictEqual('www.kth.se://bar')
+      })
+    })
+  })
+})

--- a/public/js/app/util/stringUtil.js
+++ b/public/js/app/util/stringUtil.js
@@ -15,12 +15,10 @@ function replacePathNameWithHref(element) {
   }
 }
 
-function getCurrentHost(thisHostBaseUrl, replaceAppWithWWW = true) {
+function getCurrentHost(thisHostBaseUrl, keepAppOrigin = true) {
   let hostURL = thisHostBaseUrl
-  if (origin.includes('app-') && replaceAppWithWWW) {
-    hostURL = String(thisHostBaseUrl).replace('app-', 'www-')
-    // eslint-disable-next-line no-console
-    console.warn('This host { uri : ' + hostURL + ' } needs KTH VPN. Make sure you are connected with KTH VPN.')
+  if (origin.includes('app') && keepAppOrigin) {
+    hostURL = String(thisHostBaseUrl).replace('www', 'app')
   }
   return hostURL.slice(-1) === '/' ? hostURL.slice(0, -1) : hostURL
 }

--- a/public/js/app/util/stringUtil.js
+++ b/public/js/app/util/stringUtil.js
@@ -15,12 +15,25 @@ function replacePathNameWithHref(element) {
   }
 }
 
-function getCurrentHost(thisHostBaseUrl, keepAppOrigin = true) {
-  let hostURL = thisHostBaseUrl
-  if (origin.includes('app') && keepAppOrigin) {
-    hostURL = String(thisHostBaseUrl).replace('www', 'app')
+const possiblyKeepApp = (baseUrl, keepAppOrigin) => {
+  if (window.origin.includes('app') && keepAppOrigin) {
+    return baseUrl.replace('www', 'app')
   }
-  return hostURL.slice(-1) === '/' ? hostURL.slice(0, -1) : hostURL
+  return baseUrl
+}
+
+const ensureNoTrailingSlash = currentHost => {
+  if (currentHost.endsWith('/')) {
+    return currentHost.slice(0, -1)
+  }
+
+  return currentHost
+}
+
+function getCurrentHost(baseUrl, keepAppOrigin = true) {
+  const currentHost = possiblyKeepApp(baseUrl, keepAppOrigin)
+
+  return ensureNoTrailingSlash(currentHost)
 }
 
 export { replacePathNameWithHref, getCurrentHost }


### PR DESCRIPTION
After some investigation I realized that we have a function called getCurrentHost it has an argument called replaceAppWithWWW and the default value for that is true. I assume by sending a false as it's value the problem will be solved.

And I assume to actually know if this ixed the issue we should merge the code to master and check it on ref environment.