### PR TITLE
feat(KP-335): A wrapper componet is now created to handle Errors, Lits and Table View

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -317,12 +317,12 @@ const messages = {
     errorUnknown: { text: 'An unknown error occurred - failed to retrieve course data' },
     errorEmpty: {
       header: 'Your search returned no results',
-      help: 'For help, see the link below: Instructions for searching',
+      help: '',
     },
     errorOverflow: {
       header: 'There were too many results',
       text: 'There are too many courses that match your search critera. Please specify more characters/digits in the course name or course code (example of course code: SF1624).',
-      help: 'For help, see the link below: Instructions for searching',
+      help: '', // we don't have this link anymore so we should decide what we are going to show as a help text
     },
     noQueryProvided: {
       text: 'No query restriction was specified',

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -313,7 +313,7 @@ const messages = {
     errorOverflow: {
       header: 'Sökningen gav för många träffar',
       text: 'Det finns för många kurser som matchar det du sökt på. Ange fler bokstäver/siffror i kursnamn eller kurskod (exempel på kurskod: SF1624).',
-      help: 'Mer hjälp hittar du i länken nedan: Få hjälp med sökningen',
+      help: '', // we don't have this link anymore so we should decide what we are going to show as a help text
     },
     noQueryProvided: {
       text: `Ingen frågebegränsning angavs`,

--- a/public/js/app/components/NewSearchResultDisplay/ListView/index.tsx
+++ b/public/js/app/components/NewSearchResultDisplay/ListView/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { useStore } from '../../../mobx'
+
+const { language } = useStore()
+
+import { ListViewParams } from './types'
+
+import { formatShortTerm } from '../../../../../../domain/term'
+
+const ListView: React.FC<ListViewParams> = ({ results }) => {
+  return (
+    <>
+      {results.map(({ course, searchHitInterval }, index) => {
+        const { courseCode, title } = course
+        const startTerm = searchHitInterval ? formatShortTerm(searchHitInterval.startTerm, language) : ''
+        return (
+          <p key={`${courseCode}${index}`}>
+            <b>{title}</b> {courseCode} {startTerm && `- ${startTerm}`}
+          </p>
+        )
+      })}
+    </>
+  )
+}
+
+export default ListView

--- a/public/js/app/components/NewSearchResultDisplay/ListView/types.ts
+++ b/public/js/app/components/NewSearchResultDisplay/ListView/types.ts
@@ -1,0 +1,5 @@
+import { SearchHits } from '../../../util/types/SearchApiTypes'
+
+export interface ListViewParams {
+  results: SearchHits[]
+}

--- a/public/js/app/components/NewSearchResultDisplay/TableView/index.tsx
+++ b/public/js/app/components/NewSearchResultDisplay/TableView/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const TableView: React.FC = ({}) => {
+  return <div></div>
+}
+
+export default TableView

--- a/public/js/app/components/NewSearchResultDisplay/index.tsx
+++ b/public/js/app/components/NewSearchResultDisplay/index.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react'
+
+import './style.scss'
+
+import { useStore } from '../../mobx'
+
+import {
+  SearchResultDisplayParams,
+  KoppsCourseSearchResult,
+  VIEW,
+  View,
+  SearchResultHeaderParams,
+  SearchResultComponentParams,
+} from './types'
+import { STATUS } from '../../hooks/types/UseCourseSearchTypes'
+import ListView from './ListView'
+import TableView from './TableView'
+import Article from '../Article'
+import SearchAlert from '../SearchAlert'
+
+const isKoppsCourseSearchResult = (data: string | KoppsCourseSearchResult): data is KoppsCourseSearchResult => {
+  return (data as KoppsCourseSearchResult).searchHits !== undefined
+}
+
+const SearchResultHeader: React.FC<SearchResultHeaderParams> = ({ resultsLength, language }) => (
+  <div className="search-result-header">
+    <p>
+      {language === 'en' ? `Your search returned ` : `Din sökning gav `}
+      <b>{resultsLength}</b>
+      {language === 'en' ? ` result(s).` : ` resultat.`}
+    </p>
+    <div className="toggle-view">
+      {/* This section will be completed in a future task */}
+      <span>Link</span>
+      <span>Table</span>
+    </div>
+  </div>
+)
+
+const SearchResultComponent: React.FC<SearchResultComponentParams> = ({ searchResults, view }) => {
+  switch (view) {
+    case VIEW.list:
+      return <ListView results={searchResults.searchHits} />
+    case VIEW.table:
+      return <TableView />
+    default:
+      return null
+  }
+}
+
+const NewSearchResultDisplay: React.FC<SearchResultDisplayParams> = ({ resultsState }) => {
+  const { language, languageIndex } = useStore()
+
+  const [view, setView] = useState<View>(VIEW.list)
+  const { data: searchResults, status: searchStatus, error: errorType } = resultsState
+
+  if (errorType) {
+    return <SearchAlert alertType={errorType} languageIndex={languageIndex} />
+  }
+
+  if (
+    searchStatus === STATUS.resolved &&
+    isKoppsCourseSearchResult(searchResults) &&
+    searchResults.searchHits.length > 0
+  ) {
+    return (
+      <Article>
+        <SearchResultHeader resultsLength={searchResults.searchHits.length} language={language} />
+        <SearchResultComponent searchResults={searchResults} view={view} />
+      </Article>
+    )
+  }
+
+  return null
+}
+
+export default NewSearchResultDisplay

--- a/public/js/app/components/NewSearchResultDisplay/style.scss
+++ b/public/js/app/components/NewSearchResultDisplay/style.scss
@@ -1,0 +1,7 @@
+.search-result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+// more styles will be added here

--- a/public/js/app/components/NewSearchResultDisplay/types.ts
+++ b/public/js/app/components/NewSearchResultDisplay/types.ts
@@ -1,0 +1,24 @@
+import { KoppsCourseSearchResult, KoppsCourseSearchResultState } from '../../util/types/SearchApiTypes'
+
+export { KoppsCourseSearchResult, KoppsCourseSearchResultState }
+
+export interface SearchResultDisplayParams {
+  resultsState: KoppsCourseSearchResultState
+}
+
+export interface SearchResultHeaderParams {
+  resultsLength: number
+  language: string
+}
+
+export interface SearchResultComponentParams {
+  searchResults: KoppsCourseSearchResult
+  view: View
+}
+
+export const VIEW = {
+  list: 'list',
+  table: 'table',
+} as const
+
+export type View = (typeof VIEW)[keyof typeof VIEW]

--- a/public/js/app/components/SearchInput/index.tsx
+++ b/public/js/app/components/SearchInput/index.tsx
@@ -1,15 +1,23 @@
-import React, { CSSProperties, useState, ChangeEvent, FormEvent } from 'react'
+import React, { CSSProperties, useState, useEffect, ChangeEvent, FormEvent } from 'react'
 import { useStore } from '../../mobx'
 import i18n from '../../../../../i18n'
 
 import { SearchInputProps } from './types'
 
-const SearchInputField: React.FC<SearchInputProps> = ({ caption, initialValue = '', onSubmit, disabled }) => {
+const SearchInput: React.FC<SearchInputProps> = ({ caption, initialValue = '', onSubmit, disabled }) => {
   const { languageIndex } = useStore()
   const [inputText, setInputText] = useState<string>(initialValue)
 
   const { generalSearch } = i18n.messages[languageIndex]
   const { searchLabel } = generalSearch
+
+  useEffect(() => {
+    if (initialValue !== inputText) setInputText(initialValue)
+    // This effect listens for changes in the onSubmit prop, which indirectly relates to changes in the search parameters.
+    // If the input text has been modified by the user and handleSubmit is not called (meaning the search parameters haven't been updated yet),
+    // this effect ensures that if someone changes the filters in another part of the application, if the input field's internal state doesn't match the initial value from the parent (e.g., due to manual input changes),
+    // the input field will reset to reflect the initial value passed from the parent component.
+  }, [onSubmit])
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInputText(e.target.value)
@@ -58,4 +66,4 @@ const SearchInputField: React.FC<SearchInputProps> = ({ caption, initialValue = 
   )
 }
 
-export default SearchInputField
+export default SearchInput

--- a/public/js/app/hooks/types/UseCourseSearchTypes.ts
+++ b/public/js/app/hooks/types/UseCourseSearchTypes.ts
@@ -1,0 +1,37 @@
+export const STATUS = {
+    pending: 'pending',
+    resolved: 'resolved',
+    overflow: 'overflow',
+    noQueryProvided: 'noQueryProvided',
+    noHits: 'noHits',
+    rejected: 'rejected',
+    idle: 'idle',
+  } as const
+  
+  export const ERROR_ASYNC = {
+    overflow: 'errorOverflow',
+    noQueryProvided: 'noQueryProvided',
+    noHits: 'errorEmpty',
+    rejected: 'errorUnknown',
+  } as const
+  
+  export type Status = (typeof STATUS)[keyof typeof STATUS]
+  // This is equivalent to => type Status = 'pending' | 'resolved' | 'overflow' | 'noQueryProvided' | 'noHits' | 'rejected' | 'idle';
+  
+  type ErrorAsync = (typeof ERROR_ASYNC)[keyof typeof ERROR_ASYNC]
+  // This is equivalent to => type ErrorAsync = 'errorOverflow' | 'noQueryProvided' | 'errorEmpty' | 'errorUnknown';
+  
+  export interface State<T> {
+    status: Status
+    data: T | null
+    error: ErrorAsync | string | null
+  }
+  
+  export type Action<T> =
+    | { type: 'pending' }
+    | { type: 'resolved'; data: T }
+    | { type: 'overflow' }
+    | { type: 'noQueryProvided' }
+    | { type: 'noHits' }
+    | { type: 'rejected'; error: ErrorAsync | string }
+  

--- a/public/js/app/hooks/useCourseSearch.ts
+++ b/public/js/app/hooks/useCourseSearch.ts
@@ -1,41 +1,5 @@
 import React, { useEffect, useReducer, Dispatch } from 'react'
-
-const STATUS = {
-  pending: 'pending',
-  resolved: 'resolved',
-  overflow: 'overflow',
-  noQueryProvided: 'noQueryProvided',
-  noHits: 'noHits',
-  rejected: 'rejected',
-  idle: 'idle',
-} as const
-
-const ERROR_ASYNC = {
-  overflow: 'errorOverflow',
-  noQueryProvided: 'noQueryProvided',
-  noHits: 'errorEmpty',
-  rejected: 'errorUnknown',
-} as const
-
-type Status = (typeof STATUS)[keyof typeof STATUS]
-// This is equivalent to => type Status = 'pending' | 'resolved' | 'overflow' | 'noQueryProvided' | 'noHits' | 'rejected' | 'idle';
-
-type ErrorAsync = (typeof ERROR_ASYNC)[keyof typeof ERROR_ASYNC]
-// This is equivalent to => type ErrorAsync = 'errorOverflow' | 'noQueryProvided' | 'errorEmpty' | 'errorUnknown';
-
-interface State<T> {
-  status: Status
-  data: T | null
-  error: ErrorAsync | string | null
-}
-
-type Action<T> =
-  | { type: 'pending' }
-  | { type: 'resolved'; data: T }
-  | { type: 'overflow' }
-  | { type: 'noQueryProvided' }
-  | { type: 'noHits' }
-  | { type: 'rejected'; error: ErrorAsync | string }
+import { Action, ERROR_ASYNC, STATUS, State } from './types/UseCourseSearchTypes'
 
 function asyncReducer<T>(state: State<T>, action: Action<T>): State<T> {
   switch (action.type) {
@@ -78,7 +42,8 @@ function useCourseSearch<T>(asyncCallback: () => Promise<T>, initialState?: Part
         if (errorCode && errorCode === 'search-error-overflow') overflowDispatch(dispatch)
         else if (errorCode) dispatch({ type: 'rejected', error: errorCode })
         else if (searchHits && searchHits.length === 0) noHitsDispatch(dispatch)
-        else if (!searchHits && typeof data === "string" && data.includes("ERROR-koppsCourseSearch-")) dispatch({ type: 'rejected', error: data })
+        else if (!searchHits && typeof data === 'string' && data.includes('ERROR-koppsCourseSearch-'))
+          dispatch({ type: 'rejected', error: data })
         else if (!searchHits || data === 'No query restriction was specified') noQueryProvidedDispatch(dispatch)
         else dispatch({ type: 'resolved', data })
       },
@@ -89,4 +54,4 @@ function useCourseSearch<T>(asyncCallback: () => Promise<T>, initialState?: Part
   return state
 }
 
-export { STATUS, ERROR_ASYNC, useCourseSearch }
+export { useCourseSearch }

--- a/public/js/app/pages/NewSearchPage.tsx
+++ b/public/js/app/pages/NewSearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react'
+import React from 'react'
 
 import { Col, Row } from 'reactstrap'
 import { PageHeading } from '@kth/kth-reactstrap/dist/components/studinfo'
@@ -6,16 +6,17 @@ import { SearchFilters, Lead } from '../components'
 
 import SearchInput from '../components/SearchInput'
 
-import { koppsCourseSearch, KoppsCourseSearchResult } from '../util/searchApi'
-import { STATUS, ERROR_ASYNC, useCourseSearch } from '../hooks/useCourseSearch'
+import { koppsCourseSearch } from '../util/searchApi'
+import { useCourseSearch } from '../hooks/useCourseSearch'
 
 import { useStore } from '../mobx'
 import i18n from '../../../../i18n'
 
-import { formatShortTerm } from '../../../../domain/term'
-
 import { MainContentProps } from './types/searchPageTypes'
 import { useCourseSearchParams } from '../hooks/useCourseSearchParams'
+import { STATUS } from '../hooks/types/UseCourseSearchTypes'
+import NewSearchResultDisplay from '../components/NewSearchResultDisplay'
+import { KoppsCourseSearchResultState } from '../util/types/SearchApiTypes'
 
 const MainContent: React.FC<MainContentProps> = ({ children }) => {
   return (
@@ -29,10 +30,6 @@ function _getThisHost(thisHostBaseUrl: string) {
   return thisHostBaseUrl.slice(-1) === '/' ? thisHostBaseUrl.slice(0, -1) : thisHostBaseUrl
 }
 
-function isKoppsCourseSearchResult(data: string | KoppsCourseSearchResult): data is KoppsCourseSearchResult {
-  return (data as KoppsCourseSearchResult).searchHits !== undefined
-}
-
 const NewSearchPage = () => {
   const [courseSearchParams, setCourseSearchParams] = useCourseSearchParams()
   const { pattern } = courseSearchParams
@@ -40,7 +37,7 @@ const NewSearchPage = () => {
 
   const { bigSearch, messages } = i18n.messages[languageIndex]
   const { main_menu_search_all_new } = messages
-  const { searchHeading, searchButton, leadIntro } = bigSearch
+  const { resultsHeading, searchButton, leadIntro } = bigSearch
 
   const asyncCallback = React.useCallback(() => {
     const proxyUrl = _getThisHost(browserConfig.proxyPrefixPath.uri)
@@ -49,7 +46,7 @@ const NewSearchPage = () => {
 
   const state = useCourseSearch(asyncCallback, { status: STATUS.idle })
 
-  const { data: searchResults, status: searchStatus, error: errorType } = state
+  const { status: searchStatus } = state
 
   function handlePatternChange(pattern: string) {
     setCourseSearchParams({ pattern: pattern })
@@ -64,7 +61,7 @@ const NewSearchPage = () => {
         disabled={searchStatus === STATUS.pending}
       />
       <MainContent>
-        <PageHeading>{searchHeading}</PageHeading>
+        <PageHeading>{resultsHeading}</PageHeading>
         <Lead text={leadIntro} />
         <SearchInput
           initialValue={pattern}
@@ -72,19 +69,7 @@ const NewSearchPage = () => {
           onSubmit={handlePatternChange}
           disabled={searchStatus === STATUS.pending}
         />
-        {searchStatus === STATUS.resolved &&
-          isKoppsCourseSearchResult(searchResults) &&
-          searchResults.searchHits &&
-          searchResults.searchHits.length > 0 &&
-          searchResults.searchHits.map(({ course, searchHitInterval }, index) => {
-            const { courseCode, title } = course
-            const startTerm = searchHitInterval ? formatShortTerm(searchHitInterval.startTerm, language) : ''
-            return (
-              <p key={`${courseCode}${index}`}>
-                <b>{title}</b> {courseCode} {startTerm && `- ${startTerm}`}
-              </p>
-            )
-          })}
+        <NewSearchResultDisplay resultsState={state as KoppsCourseSearchResultState} />
       </MainContent>
     </Row>
   )

--- a/public/js/app/util/searchApi.ts
+++ b/public/js/app/util/searchApi.ts
@@ -1,17 +1,7 @@
 // Importing fetch
 // Note: fetch is natively available in modern browsers and Node.js (with a fetch polyfill if needed).
 
-export interface KoppsCourseSearchParams {
-  [key: string]: any // Allowing any key-value pair as params
-}
-
-export interface KoppsCourseSearchResult {
-  searchHits?: {
-    searchHitInterval?: any
-    course: any
-  }[]
-  errorCode?: string
-}
+import { KoppsCourseSearchParams, KoppsCourseSearchResult } from "./types/SearchApiTypes"
 
 export async function koppsCourseSearch(
   language: string,

--- a/public/js/app/util/types/SearchApiTypes.ts
+++ b/public/js/app/util/types/SearchApiTypes.ts
@@ -1,0 +1,21 @@
+import { ERROR_ASYNC, STATUS } from '../../hooks/searchUseAsync'
+
+export interface KoppsCourseSearchParams {
+  [key: string]: any // Allowing any key-value pair as params
+}
+
+export interface SearchHits {
+  searchHitInterval?: { [key: string]: any }
+  course: { [key: string]: any }
+}
+
+export interface KoppsCourseSearchResult {
+  searchHits?: SearchHits[]
+  errorCode?: string
+}
+
+export interface KoppsCourseSearchResultState {
+  data: KoppsCourseSearchResult
+  status: keyof typeof STATUS | null
+  error: keyof typeof ERROR_ASYNC | null
+}


### PR DESCRIPTION
This PR is for a wrapper component for the results view which will separate the Errors, list view and table view for the results.

One tiny issue is also fixed inside the SearchInput component (it was happening when you were changing the input text and then triggering other filters in the meantime but not clicking the submit button for SearchInput)