### PR TITLE
KP-341: Fixed incorrect translations and updated test

### DIFF
--- a/public/js/app/components/SearchTableView.jsx
+++ b/public/js/app/components/SearchTableView.jsx
@@ -12,6 +12,7 @@ import i18n from '../../../../i18n'
 import { courseLink } from '../util/links'
 import { formatShortTerm } from '../../../../domain/term'
 import Article from './Article'
+import { translateCreditUnitAbbr } from '../util/translateCreditUnitAbbr'
 
 function codeCell(code, startTerm) {
   const { language } = useStore()
@@ -53,7 +54,7 @@ function periodsStr(startPeriod, startTerm, endPeriod, endTerm) {
   return `P${startPeriod} ${formatShortTerm(startTerm, language)} - P${endPeriod} ${formatShortTerm(endTerm, language)}`
 }
 
-function sortAndParseByCourseCode(courses, languageIndex, sliceUntilNum) {
+function sortAndParseByCourseCode(courses, languageIndex, language, sliceUntilNum) {
   const { bigSearch } = i18n.messages[languageIndex]
   courses.sort(compareCoursesBy('courseCode'))
   const parsedCourses = courses.map(
@@ -71,7 +72,7 @@ function sortAndParseByCourseCode(courses, languageIndex, sliceUntilNum) {
       [
         codeCell(code, startTerm),
         titleCell(code, title, startTerm),
-        `${credits} ${creditUnitAbbr}`,
+        `${credits} ${translateCreditUnitAbbr(language, creditUnitAbbr)}`,
         bigSearch[level] || '',
         periodsStr(startPeriod, startTerm, endPeriod, endTerm) || '',
       ].slice(0, sliceUntilNum)
@@ -107,7 +108,7 @@ const SearchTableView = ({ unsortedSearchResults }) => {
     t('department_period_abbr'),
   ].slice(0, sliceUntilNum)
 
-  const courses = sortAndParseByCourseCode(flatCoursesArr, languageIndex, sliceUntilNum)
+  const courses = sortAndParseByCourseCode(flatCoursesArr, languageIndex, language, sliceUntilNum)
 
   const hitsNumber = courses.length
   return (

--- a/public/js/app/components/SearchTableView.test.js
+++ b/public/js/app/components/SearchTableView.test.js
@@ -63,7 +63,7 @@ describe('Component <SearchTableView> for RESEARCH courses', () => {
         const { course } = TEST_SEARCH_RESEARCH_THIRD_CYCLE_COURSES_EN.searchHits[index]
         expect(utils.getAllByRole('cell')[0]).toHaveTextContent(course.courseCode, { exact: true })
         expect(utils.getAllByRole('cell')[1]).toHaveTextContent(course.title, { exact: true })
-        expect(utils.getAllByRole('cell')[2]).toHaveTextContent(`${course.credits} ${course.creditUnitAbbr}`, {
+        expect(utils.getAllByRole('cell')[2]).toHaveTextContent(`${course.credits} credits`, {
           exact: true,
         })
         expect(utils.getAllByRole('cell')[3]).toHaveTextContent('Third cycle')
@@ -154,7 +154,7 @@ describe('Component <SearchTableView> for RESEARCH courses', () => {
         const { course } = TEST_SEARCH_RESEARCH_THIRD_CYCLE_COURSES_EN.searchHits[index]
         expect(utils.getAllByRole('cell')[0]).toHaveTextContent(course.courseCode, { exact: true })
         expect(utils.getAllByRole('cell')[1]).toHaveTextContent(course.title, { exact: true })
-        expect(utils.getAllByRole('cell')[2]).toHaveTextContent(`${course.credits} ${course.creditUnitAbbr}`, {
+        expect(utils.getAllByRole('cell')[2]).toHaveTextContent(`${course.credits} credits`, {
           exact: true,
         })
         expect(utils.getAllByRole('cell')[3]).toHaveTextContent('Third cycle')
@@ -199,7 +199,7 @@ describe('Component <SearchTableView> for MIXED types of courses', () => {
         const { course } = EXPECTED_TEST_SEARCH_HITS_MIXED_EN.searchHits[index]
         expect(utils.getAllByRole('cell')[0]).toHaveTextContent(course.courseCode, { exact: true })
         expect(utils.getAllByRole('cell')[1]).toHaveTextContent(course.title, { exact: true })
-        expect(utils.getAllByRole('cell')[2]).toHaveTextContent(`${course.credits} ${course.creditUnitAbbr}`, {
+        expect(utils.getAllByRole('cell')[2]).toHaveTextContent(`${course.credits} credits`, {
           exact: true,
         })
         expect(utils.getAllByRole('cell')[3]).toHaveTextContent(

--- a/public/js/app/components/__snapshots__/SearchResultDisplay.test.js.snap
+++ b/public/js/app/components/__snapshots__/SearchResultDisplay.test.js.snap
@@ -185,7 +185,7 @@ exports[`Component <SearchResultDisplay> and resolved cases double search: by de
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 First cycle
@@ -207,7 +207,7 @@ exports[`Component <SearchResultDisplay> and resolved cases double search: by de
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 First cycle
@@ -325,7 +325,7 @@ exports[`Component <SearchResultDisplay> and resolved cases double search: by de
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 First cycle
@@ -350,7 +350,7 @@ exports[`Component <SearchResultDisplay> and resolved cases double search: by de
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td />
               <td>
@@ -458,7 +458,7 @@ exports[`Component <SearchResultDisplay> and resolved cases search by a text pat
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 First cycle
@@ -480,7 +480,7 @@ exports[`Component <SearchResultDisplay> and resolved cases search by a text pat
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 First cycle

--- a/public/js/app/components/__snapshots__/SearchTableView.test.js.snap
+++ b/public/js/app/components/__snapshots__/SearchTableView.test.js.snap
@@ -311,7 +311,7 @@ exports[`Component <SearchTableView> for MIXED types of courses creates a table 
                 </a>
               </td>
               <td>
-                30 hp
+                30 credits
               </td>
               <td>
                 Second cycle
@@ -336,7 +336,7 @@ exports[`Component <SearchTableView> for MIXED types of courses creates a table 
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 First cycle
@@ -361,7 +361,7 @@ exports[`Component <SearchTableView> for MIXED types of courses creates a table 
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td />
               <td>
@@ -384,7 +384,7 @@ exports[`Component <SearchTableView> for MIXED types of courses creates a table 
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 Third cycle
@@ -407,7 +407,7 @@ exports[`Component <SearchTableView> for MIXED types of courses creates a table 
                 </a>
               </td>
               <td>
-                4 hp
+                4 credits
               </td>
               <td>
                 Pre-university level
@@ -512,7 +512,7 @@ exports[`Component <SearchTableView> for RESEARCH courses creates a table with 4
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 Third cycle
@@ -534,7 +534,7 @@ exports[`Component <SearchTableView> for RESEARCH courses creates a table with 4
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 Third cycle
@@ -556,7 +556,7 @@ exports[`Component <SearchTableView> for RESEARCH courses creates a table with 4
                 </a>
               </td>
               <td>
-                3 hp
+                3 credits
               </td>
               <td>
                 Third cycle
@@ -804,7 +804,7 @@ exports[`Component <SearchTableView> for RESEARCH courses creates a table with 5
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 Third cycle
@@ -826,7 +826,7 @@ exports[`Component <SearchTableView> for RESEARCH courses creates a table with 5
                 </a>
               </td>
               <td>
-                7.5 hp
+                7.5 credits
               </td>
               <td>
                 Third cycle
@@ -848,7 +848,7 @@ exports[`Component <SearchTableView> for RESEARCH courses creates a table with 5
                 </a>
               </td>
               <td>
-                3 hp
+                3 credits
               </td>
               <td>
                 Third cycle

--- a/public/js/app/pages/Curriculum.jsx
+++ b/public/js/app/pages/Curriculum.jsx
@@ -19,6 +19,7 @@ import { formatAcademicYear, calculateStartTerm } from '../../../../domain/acade
 import { ELECTIVE_CONDITIONS } from '../../../../domain/curriculum'
 import { ORDINARY_PERIODS } from '../../../../domain/periods'
 import { courseLink, programSyllabusLink, programmeWebLink } from '../util/links'
+import { translateCreditUnitAbbr } from '../util/translateCreditUnitAbbr'
 
 function CourseTablePeriodCols({ language, creditsPerPeriod, courseCode }) {
   return ORDINARY_PERIODS.map(period => {
@@ -59,6 +60,7 @@ function CourseTableRows({ participations }) {
     const { course, applicationCodes, term, creditsPerPeriod } = participation
 
     const { courseCode, title, credits, creditUnitAbbr, comment } = course
+    const translatedCreditUnitAbbr = translateCreditUnitAbbr(language, creditUnitAbbr)
     const currentTerm = getCurrentTerm()
     const courseNameCellData = (
       <>
@@ -74,7 +76,7 @@ function CourseTableRows({ participations }) {
         courseNameCellData={courseNameCellData}
         applicationCodeCellData={applicationCodeCellData}
         credits={credits}
-        creditUnitAbbr={creditUnitAbbr}
+        creditUnitAbbr={translatedCreditUnitAbbr}
         creditsPerPeriod={creditsPerPeriod}
       />
     )

--- a/public/js/app/pages/DepartmentCourses.jsx
+++ b/public/js/app/pages/DepartmentCourses.jsx
@@ -8,6 +8,7 @@ import FooterContent from '../components/FooterContent'
 import { useStore } from '../mobx'
 import translate from '../../../../domain/translate'
 import { courseLink } from '../util/links'
+import { translateCreditUnitAbbr } from '../util/translateCreditUnitAbbr'
 
 function codeCell(code) {
   const { language } = useStore()
@@ -37,12 +38,12 @@ function compareCoursesBy(key) {
   }
 }
 
-function sortAndParseCourses(courses) {
+function sortAndParseCourses(courses, language) {
   courses.sort(compareCoursesBy('code'))
   const parsedCourses = courses.map(({ code, title, credits, creditUnitAbbr, level }) => [
     codeCell(code),
     titleCell(code, title),
-    `${credits} ${creditUnitAbbr}`,
+    `${credits} ${translateCreditUnitAbbr(language, creditUnitAbbr)}`,
     level,
   ])
   return parsedCourses
@@ -53,7 +54,7 @@ function DepartmentsList() {
   const t = translate(language)
 
   const headers = [t('course_code'), t('course_name'), t('course_scope'), t('course_educational_level')]
-  const courses = sortAndParseCourses(departmentCourses)
+  const courses = sortAndParseCourses(departmentCourses, language)
   return (
     <>
       <Row>

--- a/public/js/app/pages/ProgrammesList.jsx
+++ b/public/js/app/pages/ProgrammesList.jsx
@@ -12,6 +12,7 @@ import translate from '../../../../domain/translate'
 import { programmeLink } from '../util/links'
 import { formatShortTerm } from '../../../../domain/term'
 import Article from '../components/Article'
+import { translateCreditUnitAbbr } from '../util/translateCreditUnitAbbr'
 
 function Heading({ size, text, id }) {
   switch (size) {
@@ -44,22 +45,24 @@ function CurrentProgrammeDescription({ programme }) {
   const { language } = useStore()
   const t = translate(language)
   const { credits, creditUnitAbbr, firstAdmissionTerm } = programme
+  const translatedCreditUnitAbbr = translateCreditUnitAbbr(language, creditUnitAbbr)
   const formattedTerm = formatShortTerm(firstAdmissionTerm, language)
-  return <>{`, ${credits} ${creditUnitAbbr}, ${t('programmes_admitted_from')} ${formattedTerm}`}</>
+  return <>{`, ${credits} ${translatedCreditUnitAbbr}, ${t('programmes_admitted_from')} ${formattedTerm}`}</>
 }
 
 function ObsoleteProgrammeDescription({ programme }) {
   const { language } = useStore()
   const t = translate(language)
   const { credits, creditUnitAbbr, firstAdmissionTerm, lastAdmissionTerm } = programme
+  const translatedCreditUnitAbbr = translateCreditUnitAbbr(language, creditUnitAbbr)
   const formattedLastTerm = formatShortTerm(lastAdmissionTerm, language)
   if (firstAdmissionTerm) {
     const formattedFirstTerm = formatShortTerm(firstAdmissionTerm, language)
     return (
-      <>{`, ${credits} ${creditUnitAbbr}, ${t('programmes_admitted')} ${formattedFirstTerm}–${formattedLastTerm}`}</>
+      <>{`, ${credits} ${translatedCreditUnitAbbr}, ${t('programmes_admitted')} ${formattedFirstTerm}–${formattedLastTerm}`}</>
     )
   }
-  return <>{`, ${credits} ${creditUnitAbbr}, ${t('programmes_admitted_until')} ${formattedLastTerm}`}</>
+  return <>{`, ${credits} ${translatedCreditUnitAbbr}, ${t('programmes_admitted_until')} ${formattedLastTerm}`}</>
 }
 
 function ProgrammesListItem({ programme, variant }) {

--- a/public/js/app/pages/__snapshots__/DepartmentCourses.test.js.snap
+++ b/public/js/app/pages/__snapshots__/DepartmentCourses.test.js.snap
@@ -191,7 +191,7 @@ exports[`Render component DepartmentCourses within Layout match to snapshot in E
                     </a>
                   </td>
                   <td>
-                    6.0 hp
+                    6.0 credits
                   </td>
                   <td>
                     First cycle

--- a/public/js/app/pages/__snapshots__/DepartmentThirdCycleCourses.test.js.snap
+++ b/public/js/app/pages/__snapshots__/DepartmentThirdCycleCourses.test.js.snap
@@ -191,7 +191,7 @@ exports[`Render component DepartmentCourses within Layout for third cycle studie
                     </a>
                   </td>
                   <td>
-                    7.5 hp
+                    7.5 credits
                   </td>
                   <td>
                     Third cycle
@@ -213,7 +213,7 @@ exports[`Render component DepartmentCourses within Layout for third cycle studie
                     </a>
                   </td>
                   <td>
-                    7.5 hp
+                    7.5 credits
                   </td>
                   <td>
                     Third cycle

--- a/public/js/app/pages/__snapshots__/ProgrammesList.test.js.snap
+++ b/public/js/app/pages/__snapshots__/ProgrammesList.test.js.snap
@@ -178,7 +178,7 @@ exports[`Render component ProgrammesList within Layout match to snapshot in Engl
                   >
                     Degree Programme in Architecture (ARKIT)
                   </a>
-                  , 300 hp, admitted/batch from Autumn 07
+                  , 300 credits, admitted/batch from Autumn 07
                 </li>
               </ul>
               <details
@@ -200,7 +200,7 @@ exports[`Render component ProgrammesList within Layout match to snapshot in Engl
                       >
                         Degree Programme in Architecture (A)
                       </a>
-                      , 270 hp, admitted/batch until Spring 07
+                      , 270 credits, admitted/batch until Spring 07
                     </li>
                   </ul>
                 </div>

--- a/public/js/app/util/translateCreditUnitAbbr.js
+++ b/public/js/app/util/translateCreditUnitAbbr.js
@@ -1,0 +1,3 @@
+export const translateCreditUnitAbbr = (language, creditUnitAbbr) => {
+  return language === 'en' && creditUnitAbbr != 'fup' ? 'credits' : creditUnitAbbr
+}


### PR DESCRIPTION
All pages now display the correct translation for hp/credits/fup depending on the selected language.

Updated SearchTableView.test.js: 

creditUnitAbbr is already incorrect for english version when data is fetched from Kopps (value is 'hp' for english instead of 'credits'). Replaced it with 'credits' in the test instead.