### PR TITLE
Issues/KUI-1472 use ladok educational level code labels

### DIFF
--- a/domain/eduLevels.js
+++ b/domain/eduLevels.js
@@ -1,21 +1,25 @@
-const EDUCATION_LEVEL_MAP = {
-  FUPKURS: 'PREPARATORY',
-  '2007GKURS': 'BASIC',
-  '2007AKURS': 'ADVANCED',
-  '2007FKURS': 'RESEARCH',
+const { EducationalLevelCode } = require('@kth/om-kursen-ladok-client')
+
+const LEVEL_MAP = {
+  [EducationalLevelCode.Preparatory]: 'PREPARATORY',
+  [EducationalLevelCode.Basic]: 'BASIC',
+  [EducationalLevelCode.Advanced]: 'ADVANCED',
+  [EducationalLevelCode.Research]: 'RESEARCH',
 }
 
-const CLIENT_EDU_LEVELS = Object.keys(EDUCATION_LEVEL_MAP)
+const CLIENT_EDU_LEVELS = Object.values(EducationalLevelCode)
 
 function educationalLevel(levelCode) {
   if (typeof levelCode !== 'string') {
     throw new Error(`Invalid type for education level code: ${levelCode} (type: ${typeof levelCode})`)
   }
 
-  const level = EDUCATION_LEVEL_MAP[levelCode]
+  const level = LEVEL_MAP[levelCode]
 
   if (!level) {
-    throw new Error(`Unknown education level code: ${levelCode}. Allowed values: ${CLIENT_EDU_LEVELS.join(', ')}`)
+    throw new Error(
+      `Unknown education level number: ${levelCode}. Allowed types: ${Object.values(EducationalLevelCode).join(' , ')}]`
+    )
   }
 
   return level

--- a/domain/eduLevels.js
+++ b/domain/eduLevels.js
@@ -1,16 +1,11 @@
-const PREPARATORY_EDU_LEVEL = 'PREPARATORY'
-const BASIC_EDU_LEVEL = 'BASIC'
-const ADVANCED_EDU_LEVEL = 'ADVANCED'
-const RESEARCH_EDU_LEVEL = 'RESEARCH'
-
-const CLIENT_EDU_LEVELS = ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS']
-
 const EDUCATION_LEVEL_MAP = {
-  FUPKURS: PREPARATORY_EDU_LEVEL, // Education preparing for university studies
-  '2007GKURS': BASIC_EDU_LEVEL, // Studies at university
-  '2007AKURS': ADVANCED_EDU_LEVEL, // Doctoral studies
-  '2007FKURS': RESEARCH_EDU_LEVEL, // Post-doc studies
+  FUPKURS: 'PREPARATORY',
+  '2007GKURS': 'BASIC',
+  '2007AKURS': 'ADVANCED',
+  '2007FKURS': 'RESEARCH',
 }
+
+const CLIENT_EDU_LEVELS = Object.keys(EDUCATION_LEVEL_MAP)
 
 function educationalLevel(levelCode) {
   if (typeof levelCode !== 'string') {
@@ -20,9 +15,7 @@ function educationalLevel(levelCode) {
   const level = EDUCATION_LEVEL_MAP[levelCode]
 
   if (!level) {
-    throw new Error(
-      `Unknown education level code: ${levelCode}. Allowed values: ${Object.keys(EDUCATION_LEVEL_MAP).join(', ')}`
-    )
+    throw new Error(`Unknown education level code: ${levelCode}. Allowed values: ${CLIENT_EDU_LEVELS.join(', ')}`)
   }
 
   return level

--- a/domain/eduLevels.js
+++ b/domain/eduLevels.js
@@ -1,41 +1,31 @@
-// const { termConstants } = require('./term')
-
 const PREPARATORY_EDU_LEVEL = 'PREPARATORY'
 const BASIC_EDU_LEVEL = 'BASIC'
 const ADVANCED_EDU_LEVEL = 'ADVANCED'
 const RESEARCH_EDU_LEVEL = 'RESEARCH'
 
-const CLIENT_EDU_LEVELS = ['0', '1', '2', '3']
+const CLIENT_EDU_LEVELS = ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS']
 
-function educationalLevel(levelNumberAsStr) {
-  switch (levelNumberAsStr) {
-    /**
-     * Education preparing for university studies.
-     */
-    case '0':
-      return PREPARATORY_EDU_LEVEL
-    /**
-     * Studies at university.
-     */
-    case '1':
-      return BASIC_EDU_LEVEL
-    /**
-     * Doctoral studies.
-     */
-    case '2':
-      return ADVANCED_EDU_LEVEL
-    /**
-     * Post-doc studies.
-     */
-    case '3':
-      return RESEARCH_EDU_LEVEL
-    default: {
-      if (typeof levelNumberAsStr !== 'string')
-        throw new Error(`Check the type of level: ${levelNumberAsStr} has the type ${typeof levelNumberAsStr}`)
+const EDUCATION_LEVEL_MAP = {
+  FUPKURS: PREPARATORY_EDU_LEVEL, // Education preparing for university studies
+  '2007GKURS': BASIC_EDU_LEVEL, // Studies at university
+  '2007AKURS': ADVANCED_EDU_LEVEL, // Doctoral studies
+  '2007FKURS': RESEARCH_EDU_LEVEL, // Post-doc studies
+}
 
-      throw new Error(`Unknown education level number: ${levelNumberAsStr}. Allowed types: '0'-'3'`)
-    }
+function educationalLevel(levelCode) {
+  if (typeof levelCode !== 'string') {
+    throw new Error(`Invalid type for education level code: ${levelCode} (type: ${typeof levelCode})`)
   }
+
+  const level = EDUCATION_LEVEL_MAP[levelCode]
+
+  if (!level) {
+    throw new Error(
+      `Unknown education level code: ${levelCode}. Allowed values: ${Object.keys(EDUCATION_LEVEL_MAP).join(', ')}`
+    )
+  }
+
+  return level
 }
 
 module.exports = {

--- a/domain/searchParams.js
+++ b/domain/searchParams.js
@@ -21,24 +21,24 @@ function _transformIfSummerOrEmptyPeriods(initialPeriods) {
 
 function _transformSearchParams(params) {
   const { eduLevel = [], pattern = '', showOptions = [], period = [], department = '' } = params
-  const koppsFormatParams = {
+  const formatParams = {
     educational_level: eduLevel.map(level => educationalLevel(level)), // ['RESEARCH', 'ADVANCED'],
     flag: showOptions.map(opt => getShowOptions(opt)), // Example: flag: [only_mhu, in_english_only, include_non_active]
     term_period: _transformIfSummerOrEmptyPeriods(period), // ['2018:2']
   }
-  if (pattern) koppsFormatParams.text_pattern = pattern
-  if (department) koppsFormatParams.department_prefix = department
+  if (pattern) formatParams.text_pattern = pattern
+  if (department) formatParams.department_prefix = department
 
-  return koppsFormatParams
+  return formatParams
 }
 
 function stringifyUrlParams(params) {
   return querystring.stringify(params)
 }
 
-function stringifyKoppsSearchParams(params) {
-  const koppsFormatParams = _transformSearchParams(params)
-  const paramsStr = stringifyUrlParams(koppsFormatParams)
+function stringifySearchParams(params) {
+  const formatParams = _transformSearchParams(params)
+  const paramsStr = stringifyUrlParams(formatParams)
   return paramsStr
 }
 
@@ -197,6 +197,6 @@ function getParamConfig(paramName, langIndex) {
 
 module.exports = {
   getParamConfig,
-  stringifyKoppsSearchParams,
+  stringifyKoppsSearchParams: stringifySearchParams,
   stringifyUrlParams,
 }

--- a/domain/searchParams.js
+++ b/domain/searchParams.js
@@ -197,6 +197,6 @@ function getParamConfig(paramName, langIndex) {
 
 module.exports = {
   getParamConfig,
-  stringifyKoppsSearchParams: stringifySearchParams,
+  stringifySearchParams,
   stringifyUrlParams,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@kth/kth-reactstrap": "^0.4.78",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.2.1",
-        "@kth/om-kursen-ladok-client": "^1.2.4",
+        "@kth/om-kursen-ladok-client": "^1.3.2",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.6.0",
@@ -3131,14 +3131,14 @@
       }
     },
     "node_modules/@kth/ladok-attributvarde-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.1.0.tgz",
-      "integrity": "sha512-GMUB1PLg4boODIcw4JMQJVApBCICFeo3CLqc2+O+4dtgpEiMPc4UXXc+VvliPoPRG0fZoydnXaOH/RQyUm3S0w=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.1.1.tgz",
+      "integrity": "sha512-H1FKpzrhWY5KTA11qcwfI9AVARaBkC5KLO6puoBimwM6uyxPdkkX1leYUPLl0o14in3nz5HvLw6iTYCZ34956w=="
     },
     "node_modules/@kth/ladok-mellanlager-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.3.0.tgz",
-      "integrity": "sha512-MBs+sFimeLQkB1eOohKNHTPqsOWgEaceHiNnppyyMj/JBqzqjnTfr/PU89niz+UElHgx6XMVRt8TqBFtzs1s/Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.4.1.tgz",
+      "integrity": "sha512-gQNkLsdJy64/EiT7COthw1fMjPD/IpHsCpkU4E9RzA9GGAgiUfK1F3YAHXMejsha7ge0DBJxeDc8p9ZqaBsj7w==",
       "dependencies": {
         "openapi-fetch": "^0.13.0"
       }
@@ -3159,12 +3159,12 @@
       }
     },
     "node_modules/@kth/om-kursen-ladok-client": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.2.4.tgz",
-      "integrity": "sha512-kzCnqJNyRH0ALzriOBxrOWyE3FLs/sWzD1AJhzrC4XSrlhbu8kvTITK+u9Ed8eEpxERNI/R9pwRr0NmrcqbK/Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.3.2.tgz",
+      "integrity": "sha512-X63CqrcuuVi6AHb/nyDe3/bn8+1ug29lJWNFETBAJxVXaKfM09w2kqXnb3QM/45DN2teSG2A5d+4t2kHNvuOrA==",
       "dependencies": {
-        "@kth/ladok-attributvarde-utils": "0.1.0",
-        "@kth/ladok-mellanlager-client": "0.3.0",
+        "@kth/ladok-attributvarde-utils": "0.1.1",
+        "@kth/ladok-mellanlager-client": "0.4.1",
         "date-fns": "^4.1.0",
         "showdown": "^2.1.0"
       }
@@ -12936,6 +12936,7 @@
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.5.tgz",
       "integrity": "sha512-AQK8T9GSKFREFlN1DBXTYsLjs7YV2tZcJ7zUWxbjMoQmj8dDSFRrzhLCbHPZWA1TMV3vACqfCxLEZcwf2wxV6Q==",
+      "license": "MIT",
       "dependencies": {
         "openapi-typescript-helpers": "^0.0.15"
       }
@@ -12943,7 +12944,8 @@
     "node_modules/openapi-typescript-helpers": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "kth-style": "^10.3.0",
     "mobx": "^6.12.0",
     "mobx-react": "^9.1.0",
-    "@kth/om-kursen-ladok-client": "^1.2.4",
+    "@kth/om-kursen-ladok-client": "^1.3.2",
     "prop-types": "^15.8.1",
     "querystring": "^0.2.1",
     "react": "^18.2.0",

--- a/public/js/app/components/SearchFilters/index.tsx
+++ b/public/js/app/components/SearchFilters/index.tsx
@@ -15,6 +15,7 @@ import {
   ShowOptions,
 } from '../../stores/types/searchPageStoreTypes'
 import { SEARCH_MODES } from '../../pages/types/searchPageTypes'
+import { EducationalLevelCode } from '@kth/om-kursen-ladok-client'
 const SearchFilters: React.FC<SearchFiltersProps> = ({
   disabled,
   courseSearchParams,
@@ -40,7 +41,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
   function handleClearFilters() {
     setCourseSearchParams({
       semesters: [],
-      eduLevel: searchMode === SEARCH_MODES.thirdCycleCourses ? ['2007FKURS'] : [],
+      eduLevel: searchMode === SEARCH_MODES.thirdCycleCourses ? [EducationalLevelCode.Research] : [],
       showOptions: [],
       department: '',
     })

--- a/public/js/app/components/SearchFilters/index.tsx
+++ b/public/js/app/components/SearchFilters/index.tsx
@@ -40,7 +40,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
   function handleClearFilters() {
     setCourseSearchParams({
       semesters: [],
-      eduLevel: searchMode === SEARCH_MODES.thirdCycleCourses ? ['3'] : [],
+      eduLevel: searchMode === SEARCH_MODES.thirdCycleCourses ? ['2007FKURS'] : [],
       showOptions: [],
       department: '',
     })

--- a/public/js/app/components/mocks/mockSearchHits.ts
+++ b/public/js/app/components/mocks/mockSearchHits.ts
@@ -343,7 +343,7 @@ const TEST_SEARCH_HITS_MIXED_EN = {
             en: 'Credits',
           },
           level: {
-            code: '0',
+            code: '99',
             name: 'PREPARATORY',
           },
         },
@@ -732,7 +732,7 @@ const TEST_SEARCH_HITS_MIXED_SV = {
             en: 'Credits',
           },
           level: {
-            code: '0',
+            code: '99',
             name: 'PREPARATORY',
           },
         },
@@ -1137,7 +1137,7 @@ const EXPECTED_TEST_SEARCH_HITS_MIXED_EN = {
             en: 'Credits',
           },
           level: {
-            code: '0',
+            code: '99',
             name: 'PREPARATORY',
           },
         },
@@ -1525,7 +1525,7 @@ const EXPECTED_TEST_SEARCH_HITS_MIXED_SV = {
             en: 'Credits',
           },
           level: {
-            code: '0',
+            code: '99',
             name: 'PREPARATORY',
           },
         },

--- a/public/js/app/hooks/tests/useLangHrefUpdates.test.tsx
+++ b/public/js/app/hooks/tests/useLangHrefUpdates.test.tsx
@@ -49,27 +49,27 @@ describe('useLangHrefUpdate', () => {
       pattern: 'test',
       department: 'A',
       semesters: ['HT2024', 'VT2025', 'HT2025'],
-      eduLevel: ['0', '1', '2', '3'],
+      eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
       showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
     }
 
     render(<TestComponent courseSearchParams={courseSearchParams} />)
 
     expect(mockLanguageAnchor?.href).toContain(
-      '?pattern=test&department=A&semesters=HT2024&semesters=VT2025&semesters=HT2025&eduLevel=0&eduLevel=1&eduLevel=2&eduLevel=3&showOptions=onlyEnglish&showOptions=onlyMHU&showOptions=showCancelled&l=se'
+      '?pattern=test&department=A&semesters=HT2024&semesters=VT2025&semesters=HT2025&eduLevel=FUPKURS&eduLevel=2007GKURS&eduLevel=2007AKURS&eduLevel=2007FKURS&showOptions=onlyEnglish&showOptions=onlyMHU&showOptions=showCancelled&l=se'
     )
   })
 
   test('filters out empty, null, or undefined search params', () => {
     const courseSearchParams = {
       pattern: '',
-      eduLevel: ['0'],
+      eduLevel: ['FUPKURS'],
       department: undefined as any,
       semesters: [] as any,
     }
 
     render(<TestComponent courseSearchParams={courseSearchParams} />)
 
-    expect(mockLanguageAnchor?.href).toContain('?eduLevel=0&l=se')
+    expect(mockLanguageAnchor?.href).toContain('?eduLevel=FUPKURS&l=se')
   })
 })

--- a/public/js/app/hooks/tests/useLangHrefUpdates.test.tsx
+++ b/public/js/app/hooks/tests/useLangHrefUpdates.test.tsx
@@ -49,27 +49,27 @@ describe('useLangHrefUpdate', () => {
       pattern: 'test',
       department: 'A',
       semesters: ['HT2024', 'VT2025', 'HT2025'],
-      eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+      eduLevel: ['99', '1', '2', '3'],
       showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
     }
 
     render(<TestComponent courseSearchParams={courseSearchParams} />)
 
     expect(mockLanguageAnchor?.href).toContain(
-      '?pattern=test&department=A&semesters=HT2024&semesters=VT2025&semesters=HT2025&eduLevel=FUPKURS&eduLevel=2007GKURS&eduLevel=2007AKURS&eduLevel=2007FKURS&showOptions=onlyEnglish&showOptions=onlyMHU&showOptions=showCancelled&l=se'
+      '?pattern=test&department=A&semesters=HT2024&semesters=VT2025&semesters=HT2025&eduLevel=99&eduLevel=1&eduLevel=2&eduLevel=3&showOptions=onlyEnglish&showOptions=onlyMHU&showOptions=showCancelled&l=se'
     )
   })
 
   test('filters out empty, null, or undefined search params', () => {
     const courseSearchParams = {
       pattern: '',
-      eduLevel: ['FUPKURS'],
+      eduLevel: ['99'],
       department: undefined as any,
       semesters: [] as any,
     }
 
     render(<TestComponent courseSearchParams={courseSearchParams} />)
 
-    expect(mockLanguageAnchor?.href).toContain('?eduLevel=FUPKURS&l=se')
+    expect(mockLanguageAnchor?.href).toContain('?eduLevel=99&l=se')
   })
 })

--- a/public/js/app/pages/SearchLandingPage.test.tsx
+++ b/public/js/app/pages/SearchLandingPage.test.tsx
@@ -5,6 +5,7 @@ import SearchLandingPage from './SearchLandingPage'
 import { useStore } from '../mobx'
 import { useNavigate } from 'react-router-dom'
 import { stringifyUrlParams } from '../../../../domain/searchParams'
+import { EducationalLevelCode } from '@kth/om-kursen-ladok-client'
 
 const mockDate = new Date('2024-08-19 16:00')
 
@@ -81,7 +82,12 @@ describe('<searchLandingPage />', () => {
 
     const searchParams = stringifyUrlParams({
       semesters: ['HT2024', 'VT2025', 'HT2025'],
-      eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+      eduLevel: [
+        EducationalLevelCode.Preparatory,
+        EducationalLevelCode.Basic,
+        EducationalLevelCode.Advanced,
+        EducationalLevelCode.Research,
+      ],
       showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
     })
 
@@ -154,7 +160,7 @@ describe('<searchLandingPage />', () => {
 
     const searchParams = stringifyUrlParams({
       semesters: ['HT2024'],
-      eduLevel: ['FUPKURS'],
+      eduLevel: ['99'],
       showOptions: ['onlyEnglish'],
     })
 

--- a/public/js/app/pages/SearchLandingPage.test.tsx
+++ b/public/js/app/pages/SearchLandingPage.test.tsx
@@ -5,7 +5,6 @@ import SearchLandingPage from './SearchLandingPage'
 import { useStore } from '../mobx'
 import { useNavigate } from 'react-router-dom'
 import { stringifyUrlParams } from '../../../../domain/searchParams'
-import { EducationalLevelCode } from '@kth/om-kursen-ladok-client'
 
 const mockDate = new Date('2024-08-19 16:00')
 
@@ -82,12 +81,7 @@ describe('<searchLandingPage />', () => {
 
     const searchParams = stringifyUrlParams({
       semesters: ['HT2024', 'VT2025', 'HT2025'],
-      eduLevel: [
-        EducationalLevelCode.Preparatory,
-        EducationalLevelCode.Basic,
-        EducationalLevelCode.Advanced,
-        EducationalLevelCode.Research,
-      ],
+      eduLevel: ['99', '1', '2', '3'],
       showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
     })
 

--- a/public/js/app/pages/SearchLandingPage.test.tsx
+++ b/public/js/app/pages/SearchLandingPage.test.tsx
@@ -81,7 +81,7 @@ describe('<searchLandingPage />', () => {
 
     const searchParams = stringifyUrlParams({
       semesters: ['HT2024', 'VT2025', 'HT2025'],
-      eduLevel: ['0', '1', '2', '3'],
+      eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
       showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
     })
 
@@ -154,7 +154,7 @@ describe('<searchLandingPage />', () => {
 
     const searchParams = stringifyUrlParams({
       semesters: ['HT2024'],
-      eduLevel: ['0'],
+      eduLevel: ['FUPKURS'],
       showOptions: ['onlyEnglish'],
     })
 

--- a/public/js/app/pages/SearchPage.test.tsx
+++ b/public/js/app/pages/SearchPage.test.tsx
@@ -68,7 +68,7 @@ describe('<SearchPage />', () => {
     mockSearchParams.append('pattern', 'Math')
     mockSearchParams.append('semesters', 'HT2024')
     mockSearchParams.append('semesters', 'VT2024')
-    mockSearchParams.append('eduLevel', '1')
+    mockSearchParams.append('eduLevel', '2007GKURS')
     mockSearchParams.append('showOptions', 'onlyEnglish')
     ;(courseSearch as jest.Mock).mockReturnValue(Promise.resolve(TEST_API_ANSWER_RESOLVED))
 
@@ -77,7 +77,7 @@ describe('<SearchPage />', () => {
     expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
       pattern: 'Math',
       semesters: ['HT2024', 'VT2024'],
-      eduLevel: ['1'],
+      eduLevel: ['2007GKURS'],
       showOptions: ['onlyEnglish'],
       department: '',
     })
@@ -207,7 +207,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0'],
+        eduLevel: ['FUPKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -221,7 +221,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0', '1'],
+        eduLevel: ['FUPKURS', '2007GKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -235,7 +235,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0', '1', '2'],
+        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -249,7 +249,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0', '1', '2', '3'],
+        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -263,7 +263,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0', '1', '2', '3'],
+        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish'],
       })
@@ -277,7 +277,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0', '1', '2', '3'],
+        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish', 'onlyMHU'],
       })
@@ -291,7 +291,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['0', '1', '2', '3'],
+        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
       })

--- a/public/js/app/pages/SearchPage.test.tsx
+++ b/public/js/app/pages/SearchPage.test.tsx
@@ -5,6 +5,7 @@ import SearchPage from './SearchPage'
 import { useStore } from '../mobx'
 import { courseSearch } from '../util/searchApi'
 import { TEST_API_ANSWER_RESOLVED } from '../components/mocks/mockKoppsCourseSearch'
+import { EducationalLevelCode } from '@kth/om-kursen-ladok-client'
 
 const periods = ['Autumn 2024', 'Spring 2025', 'Autumn 2025']
 const eduLevels = ['Pre-university level', 'First cycle', 'Second cycle', 'Third cycle']
@@ -68,7 +69,7 @@ describe('<SearchPage />', () => {
     mockSearchParams.append('pattern', 'Math')
     mockSearchParams.append('semesters', 'HT2024')
     mockSearchParams.append('semesters', 'VT2024')
-    mockSearchParams.append('eduLevel', '2007GKURS')
+    mockSearchParams.append('eduLevel', EducationalLevelCode.Basic)
     mockSearchParams.append('showOptions', 'onlyEnglish')
     ;(courseSearch as jest.Mock).mockReturnValue(Promise.resolve(TEST_API_ANSWER_RESOLVED))
 
@@ -77,7 +78,7 @@ describe('<SearchPage />', () => {
     expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
       pattern: 'Math',
       semesters: ['HT2024', 'VT2024'],
-      eduLevel: ['2007GKURS'],
+      eduLevel: [EducationalLevelCode.Basic],
       showOptions: ['onlyEnglish'],
       department: '',
     })
@@ -207,7 +208,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS'],
+        eduLevel: [EducationalLevelCode.Preparatory],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -221,7 +222,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS', '2007GKURS'],
+        eduLevel: [EducationalLevelCode.Preparatory, EducationalLevelCode.Basic],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -235,7 +236,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS'],
+        eduLevel: [EducationalLevelCode.Preparatory, EducationalLevelCode.Basic, EducationalLevelCode.Advanced],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -249,7 +250,12 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+        eduLevel: [
+          EducationalLevelCode.Preparatory,
+          EducationalLevelCode.Basic,
+          EducationalLevelCode.Advanced,
+          EducationalLevelCode.Research,
+        ],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -263,7 +269,12 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+        eduLevel: [
+          EducationalLevelCode.Preparatory,
+          EducationalLevelCode.Basic,
+          EducationalLevelCode.Advanced,
+          EducationalLevelCode.Research,
+        ],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish'],
       })
@@ -277,7 +288,12 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+        eduLevel: [
+          EducationalLevelCode.Preparatory,
+          EducationalLevelCode.Basic,
+          EducationalLevelCode.Advanced,
+          EducationalLevelCode.Research,
+        ],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish', 'onlyMHU'],
       })
@@ -291,7 +307,12 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+        eduLevel: [
+          EducationalLevelCode.Preparatory,
+          EducationalLevelCode.Basic,
+          EducationalLevelCode.Advanced,
+          EducationalLevelCode.Research,
+        ],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
       })

--- a/public/js/app/pages/SearchPage.test.tsx
+++ b/public/js/app/pages/SearchPage.test.tsx
@@ -5,7 +5,6 @@ import SearchPage from './SearchPage'
 import { useStore } from '../mobx'
 import { courseSearch } from '../util/searchApi'
 import { TEST_API_ANSWER_RESOLVED } from '../components/mocks/mockKoppsCourseSearch'
-import { EducationalLevelCode } from '@kth/om-kursen-ladok-client'
 
 const periods = ['Autumn 2024', 'Spring 2025', 'Autumn 2025']
 const eduLevels = ['Pre-university level', 'First cycle', 'Second cycle', 'Third cycle']
@@ -69,7 +68,7 @@ describe('<SearchPage />', () => {
     mockSearchParams.append('pattern', 'Math')
     mockSearchParams.append('semesters', 'HT2024')
     mockSearchParams.append('semesters', 'VT2024')
-    mockSearchParams.append('eduLevel', EducationalLevelCode.Basic)
+    mockSearchParams.append('eduLevel', '1')
     mockSearchParams.append('showOptions', 'onlyEnglish')
     ;(courseSearch as jest.Mock).mockReturnValue(Promise.resolve(TEST_API_ANSWER_RESOLVED))
 
@@ -78,7 +77,7 @@ describe('<SearchPage />', () => {
     expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
       pattern: 'Math',
       semesters: ['HT2024', 'VT2024'],
-      eduLevel: [EducationalLevelCode.Basic],
+      eduLevel: ['1'],
       showOptions: ['onlyEnglish'],
       department: '',
     })
@@ -208,7 +207,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [EducationalLevelCode.Preparatory],
+        eduLevel: ['99'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -222,7 +221,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [EducationalLevelCode.Preparatory, EducationalLevelCode.Basic],
+        eduLevel: ['99', '1'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -236,7 +235,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [EducationalLevelCode.Preparatory, EducationalLevelCode.Basic, EducationalLevelCode.Advanced],
+        eduLevel: ['99', '1', '2'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -250,12 +249,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [
-          EducationalLevelCode.Preparatory,
-          EducationalLevelCode.Basic,
-          EducationalLevelCode.Advanced,
-          EducationalLevelCode.Research,
-        ],
+        eduLevel: ['99', '1', '2', '3'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: [],
       })
@@ -269,12 +263,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [
-          EducationalLevelCode.Preparatory,
-          EducationalLevelCode.Basic,
-          EducationalLevelCode.Advanced,
-          EducationalLevelCode.Research,
-        ],
+        eduLevel: ['99', '1', '2', '3'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish'],
       })
@@ -288,12 +277,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [
-          EducationalLevelCode.Preparatory,
-          EducationalLevelCode.Basic,
-          EducationalLevelCode.Advanced,
-          EducationalLevelCode.Research,
-        ],
+        eduLevel: ['99', '1', '2', '3'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish', 'onlyMHU'],
       })
@@ -307,12 +291,7 @@ describe('<SearchPage />', () => {
       expect(courseSearch).toHaveBeenCalledWith('en', '/student/kurser', {
         pattern: '',
         department: '',
-        eduLevel: [
-          EducationalLevelCode.Preparatory,
-          EducationalLevelCode.Basic,
-          EducationalLevelCode.Advanced,
-          EducationalLevelCode.Research,
-        ],
+        eduLevel: ['99', '1', '2', '3'],
         semesters: ['HT2024', 'VT2025', 'HT2025'],
         showOptions: ['onlyEnglish', 'onlyMHU', 'showCancelled'],
       })

--- a/public/js/app/stores/types/searchPageStoreTypes.ts
+++ b/public/js/app/stores/types/searchPageStoreTypes.ts
@@ -13,7 +13,7 @@ export type SchoolsWithDepartments = {
 
 export type SetSchoolsWithDepartments = (schoolsWithDepartments: SchoolsWithDepartments[]) => void
 
-export type EduLevel = '0' | '1' | '2' | '3'
+export type EduLevel = 'FUPKURS' | '2007GKURS' | '2007AKURS' | '2007FKURS'
 
 export type SetEduLevels = (eduLevels: EduLevel[]) => void
 

--- a/public/js/app/stores/types/searchPageStoreTypes.ts
+++ b/public/js/app/stores/types/searchPageStoreTypes.ts
@@ -1,3 +1,5 @@
+import { EducationalLevelCode } from "@kth/om-kursen-ladok-client"
+
 export type Pattern = string
 
 export type SetPattern = (textPattern: Pattern) => void
@@ -13,7 +15,7 @@ export type SchoolsWithDepartments = {
 
 export type SetSchoolsWithDepartments = (schoolsWithDepartments: SchoolsWithDepartments[]) => void
 
-export type EduLevel = 'FUPKURS' | '2007GKURS' | '2007AKURS' | '2007FKURS'
+export type EduLevel = `${EducationalLevelCode}`
 
 export type SetEduLevels = (eduLevels: EduLevel[]) => void
 

--- a/server/controllers/searchPageCtrl.js
+++ b/server/controllers/searchPageCtrl.js
@@ -13,7 +13,6 @@ const { browser: browserConfig, server: serverConfig } = require('../configurati
 const { createBreadcrumbs, createThirdCycleBreadcrumbs } = require('../utils/breadcrumbUtil')
 const { getServerSideFunctions } = require('../utils/serverSideRendering')
 const { compareSchools, filterOutDeprecatedSchools } = require('../../domain/schools')
-const { stringifyKoppsSearchParams } = require('../../domain/searchParams')
 const term = require('../../domain/term')
 
 async function renderSearchPage(

--- a/server/controllers/searchPageCtrl.js
+++ b/server/controllers/searchPageCtrl.js
@@ -118,7 +118,7 @@ async function performCourseSearch(req, res, next) {
   // }, []) // todo - we can use it again when we had the data for periods from ladok
 
   const convertedEduLevels = query.eduLevel?.map(level => {
-    if (level === '0') return 'FUPKURS'
+    if (level === '99') return 'FUPKURS'
     if (level === '1') return '2007GKURS'
     if (level === '2') return '2007AKURS'
     if (level === '3') return '2007FKURS'
@@ -130,7 +130,7 @@ async function performCourseSearch(req, res, next) {
     sprak: query.showOptions?.includes('onlyEnglish') ? 'ENG' : undefined,
     avvecklad: query.showOptions?.includes('showCancelled') ? 'true' : undefined,
     startPeriod: query.semesters ?? undefined,
-    utbildningsniva: convertedEduLevels ?? undefined,
+    utbildningsniva: query.eduLevel ?? undefined,
   }
 
   try {

--- a/server/controllers/searchPageCtrl.js
+++ b/server/controllers/searchPageCtrl.js
@@ -117,13 +117,6 @@ async function performCourseSearch(req, res, next) {
   //   return acc
   // }, []) // todo - we can use it again when we had the data for periods from ladok
 
-  const convertedEduLevels = query.eduLevel?.map(level => {
-    if (level === '99') return 'FUPKURS'
-    if (level === '1') return '2007GKURS'
-    if (level === '2') return '2007AKURS'
-    if (level === '3') return '2007FKURS'
-  }) // todo - this can be moved to search params after we are done with ladokAPI and we are sure about the values
-
   const searchParams = {
     kodEllerBenamning: query.pattern ? query.pattern : undefined,
     organisation: query.department ? query.department : undefined,

--- a/server/controllers/searchPageCtrl.test.js
+++ b/server/controllers/searchPageCtrl.test.js
@@ -71,7 +71,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
 
   test('search by one educational level param in english', async () => {
     searchCourses.mockReturnValue(Promise.resolve(TEST_API_ANSWER_ALGEBRA))
-    await performCourseSearch(mReq({ eduLevel: ['FUPKURS'] }, langEn), mRes, mockNext())
+    await performCourseSearch(mReq({ eduLevel: ['99'] }, langEn), mRes, mockNext())
 
     expect(ladokApi.searchCourses).toHaveBeenCalledWith(
       {
@@ -80,7 +80,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
         organisation: undefined,
         sprak: undefined,
         startPeriod: undefined,
-        utbildningsniva: ['FUPKURS'],
+        utbildningsniva: ['99'],
       },
       'en'
     )

--- a/server/controllers/searchPageCtrl.test.js
+++ b/server/controllers/searchPageCtrl.test.js
@@ -71,7 +71,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
 
   test('search by one educational level param in english', async () => {
     searchCourses.mockReturnValue(Promise.resolve(TEST_API_ANSWER_ALGEBRA))
-    await performCourseSearch(mReq({ eduLevel: ['0'] }, langEn), mRes, mockNext())
+    await performCourseSearch(mReq({ eduLevel: ['FUPKURS'] }, langEn), mRes, mockNext())
 
     expect(ladokApi.searchCourses).toHaveBeenCalledWith(
       {
@@ -88,7 +88,11 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
   })
   test('search by all educational level param in english', async () => {
     searchCourses.mockReturnValue(Promise.resolve(TEST_API_ANSWER_ALGEBRA))
-    await performCourseSearch(mReq({ eduLevel: ['0', '1', '2', '3'] }, langEn), mRes, mockNext())
+    await performCourseSearch(
+      mReq({ eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'] }, langEn),
+      mRes,
+      mockNext()
+    )
 
     expect(ladokApi.searchCourses).toHaveBeenCalledWith(
       {
@@ -164,7 +168,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
     await performCourseSearch(
       mReq(
         {
-          eduLevel: ['0', '1', '2', '3'],
+          eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
           department: 'ADB',
           semesters: ['HT2021', 'VT2021'],
           pattern: 'Algebra',

--- a/server/controllers/searchPageCtrl.test.js
+++ b/server/controllers/searchPageCtrl.test.js
@@ -88,11 +88,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
   })
   test('search by all educational level param in english', async () => {
     searchCourses.mockReturnValue(Promise.resolve(TEST_API_ANSWER_ALGEBRA))
-    await performCourseSearch(
-      mReq({ eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'] }, langEn),
-      mRes,
-      mockNext()
-    )
+    await performCourseSearch(mReq({ eduLevel: ['99', '1', '2', '3'] }, langEn), mRes, mockNext())
 
     expect(ladokApi.searchCourses).toHaveBeenCalledWith(
       {
@@ -101,7 +97,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
         organisation: undefined,
         sprak: undefined,
         startPeriod: undefined,
-        utbildningsniva: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+        utbildningsniva: ['99', '1', '2', '3'],
       },
       'en'
     )
@@ -168,7 +164,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
     await performCourseSearch(
       mReq(
         {
-          eduLevel: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+          eduLevel: ['99', '1', '2', '3'],
           department: 'ADB',
           semesters: ['HT2021', 'VT2021'],
           pattern: 'Algebra',
@@ -187,7 +183,7 @@ describe('Controller searchCtrl, function performCourseSearch', () => {
         organisation: 'ADB',
         sprak: 'ENG',
         startPeriod: ['HT2021', 'VT2021'],
-        utbildningsniva: ['FUPKURS', '2007GKURS', '2007AKURS', '2007FKURS'],
+        utbildningsniva: ['99', '1', '2', '3'],
       },
       'en'
     )


### PR DESCRIPTION
Moved hardcoded logic for preparatory educational level to `studadm-om-kursen-packages/ladok-attributvarde-utils`  and introduced mapping of educational level to educational types in `searchCourses` endpoint `studadm-om-kursen-packages/om-kursen-ladok-client`: https://github.com/KTH/studadm-om-kursen-packages/pull/61/files

### For testing
**No educational level chosen**
http://localhost:3000/student/kurser/sokkurs/resultat?pattern=Fysik&semesters=HT2025
Should show **56 search hits**

**Preparatory educational level chosen**
http://localhost:3000/student/kurser/sokkurs/resultat?pattern=Fysik&semesters=HT2025&eduLevel=99
Should show **3 search hits**

**Basic educational level chosen**
http://localhost:3000/student/kurser/sokkurs/resultat?pattern=Fysik&semesters=HT2025&eduLevel=1
Should show **15 search hits**

**Advanced educational level chosen**
http://localhost:3000/student/kurser/sokkurs/resultat?pattern=Fysik&semesters=HT2025&eduLevel=2
Should show **37 search hits**

**Research educational level chosen**
http://localhost:3000/student/kurser/sokkurs/resultat?pattern=Fysik&semesters=HT2025&eduLevel=2
Should show **1 search hits**