### PR TITLE
refactor(KP-378): update ladokMellanlagerApi defaults

### DIFF
--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -46,16 +46,12 @@ module.exports = {
   // Kopps
   koppsApi: unpackKOPPSConfig('KOPPS_API_BASEURL', devKoppsApi),
 
-  // TODO(Ladok-POC): Replace devDefaults and add values to ref/prod.parameters.json when final mellanlager is deployed
   ladokMellanlagerApi: {
-    clientId: getEnv('LADOK_AUTH_CLIENT_ID', devDefaults('c978bff4-80c6-42d2-8d64-a6d90227013b')),
+    clientId: getEnv('LADOK_AUTH_CLIENT_ID', null),
     clientSecret: getEnv('LADOK_AUTH_CLIENT_SECRET', null),
-    tokenUrl: getEnv(
-      'LADOK_AUTH_TOKEN_URL',
-      devDefaults('https://login.microsoftonline.com/acd7f330-d613-48d9-85f2-258b1ac4a015/oauth2/v2.0/token')
-    ),
-    scope: getEnv('LADOK_AUTH_SCOPE', devDefaults('api://4afd7e46-019e-44e1-9630-12fdf9d31d02/.default')),
-    baseUrl: getEnv('LADOK_BASE_URL', devDefaults('https://ladok-mellanlagring-lab.azure-api.net')),
+    tokenUrl: getEnv('LADOK_AUTH_TOKEN_URL', null),
+    scope: getEnv('LADOK_AUTH_SCOPE', null),
+    baseUrl: getEnv('LADOK_BASE_URL', null),
     ocpApimSubscriptionKey: getEnv('LADOK_OCP_APIM_SUBSCRIPTION_KEY', null),
   },
 


### PR DESCRIPTION
We already had these in both PROD.parameters.json and REF.parameters.json:

        "LADOK_AUTH_CLIENT_ID",
        "LADOK_AUTH_CLIENT_SECRET",
        "LADOK_AUTH_SCOPE",
        "LADOK_AUTH_TOKEN_URL",
        "LADOK_OCP_APIM_SUBSCRIPTION_KEY",
        "LADOK_BASE_URL"